### PR TITLE
4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Compress Changelog
 
-## 4.0.1 - 2022-06-17
+## 4.0.1 - Unreleased
 ### Added
 - Added "Default Volume Subdirectory" settings to control where assets are stored.
 - Added ability to specify output archive name
-
+- Added setting to delete stale archives during garbage collection.
 ### Changed
 - Archives created in volumes without public URLs will now be proxied through the server to be fulfilled
 - Files are now streamed into archives instead of being copied to temporary files
+- Running "getLazyLink" will now always return a controller URL instead of a direct link to assets. This should help prevent caching issues.
 
 ## 4.0.0 - 2022-06-16
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Compress Changelog
 
-## 4.0.1 - Unreleased
+## 4.0.1 - 2022-06-17
 ### Added
 - Added "Default Volume Subdirectory" settings to control where assets are stored.
 - Added ability to specify output archive name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.1 - 2022-06-17
 ### Added
 - Added "Default Volume Subdirectory" settings to control where assets are stored.
+- Added ability to specify output archive name
 
 ### Changed
 - Archives created in volumes without public URLs will now be proxied through the server to be fulfilled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Compress Changelog
 
+## 4.0.1 - 2022-06-17
+### Added
+- Added "Default Volume Subdirectory" settings to control where assets are stored.
+
+### Changed
+- Archives created in volumes without public URLs will now be proxied through the server to be fulfilled
+- Files are now streamed into archives instead of being copied to temporary files
+
 ## 4.0.0 - 2022-06-16
 ### Change
 - Compress now requires Craft 4

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ settings and life choices.
     Second parameter is whether we want the archive generated on page 
     load or lazily.
     #}
-    {% set archive = craft.compress.zip(assets, true) %}
+    {% set archive = craft.compress.zip(assets, true, 'My Photos') %}
     
     {# 
     the archive variable is now set to an Archive model, but since 
@@ -98,8 +98,6 @@ generates a lazy link to download all assets of a particular kind.
 ## Caveats & Limitations
 - Consider the Assets created by Compress to be temporary. Don't try
 to use them in Asset relation fields.
-- There's currently no way to override the filename on archives due to
-technical limitations.
 - There's currently nothing to purge stale archive assets, so if you have a
 template that queries a variable set of assets, each time the result
 set changes, a new archive asset will be created and the prior will not

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ settings and life choices.
     {# 
     the archive variable is now set to an Archive model, but since 
     we're in lazy mode, the getAsset() response may be null. We can
-    either check the .isReady method or we can just get the lazyLink
+    either check the .isReady method or we can just get the lazyLink, which will give us an indirect link to the asset.
     #}
     {% if archive.isReady %}
         {% set archiveAsset = archive.getAsset() %}
@@ -98,8 +98,6 @@ generates a lazy link to download all assets of a particular kind.
 ## Caveats & Limitations
 - Consider the Assets created by Compress to be temporary. Don't try
 to use them in Asset relation fields.
-- There's currently nothing to purge stale archive assets, so if you have a
-template that queries a variable set of assets, each time the result
 set changes, a new archive asset will be created and the prior will not
 be automatically deleted.
 

--- a/README.md
+++ b/README.md
@@ -100,5 +100,6 @@ generates a lazy link to download all assets of a particular kind.
 to use them in Asset relation fields.
 set changes, a new archive asset will be created and the prior will not
 be automatically deleted.
+- When you provide a name for your archive, it's a good idea to ensure that name is unique to the files you're zipping up. Failure to do so could result in the file not being cached well and being constantly overwritten. 
 
 Brought to you by [Venveo](https://www.venveo.com)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "venveo/craft-compress",
     "description": "Create smart zip files from Craft assets on the fly",
     "type": "craft-plugin",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/Compress.php
+++ b/src/Compress.php
@@ -34,16 +34,10 @@ use yii\base\Event;
  */
 class Compress extends Plugin
 {
-    // Static Properties
-    // =========================================================================
-
     /**
      * @var Compress
      */
     public static $plugin;
-
-    // Public Properties
-    // =========================================================================
 
     /**
      * @var string
@@ -52,9 +46,6 @@ class Compress extends Plugin
 
     public bool $hasCpSettings = true;
 
-    // Public Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      */
@@ -62,10 +53,6 @@ class Compress extends Plugin
     {
         parent::init();
         self::$plugin = $this;
-
-        $this->setComponents([
-            'compress' => CompressService::class
-        ]);
 
         Event::on(
             CraftVariable::class,
@@ -111,13 +98,25 @@ class Compress extends Plugin
 
     }
 
+    /**
+     * @inheritdoc
+     */
+    public static function config(): array
+    {
+        return [
+            'components' => [
+                'compress' => ['class' => CompressService::class]
+            ],
+        ];
+    }
+
     // Protected Methods
     // =========================================================================
 
     /**
      * @inheritdoc
      */
-    protected function createSettingsModel(): ?\craft\base\Model
+    protected function createSettingsModel(): Settings
     {
         return new Settings();
     }

--- a/src/Compress.php
+++ b/src/Compress.php
@@ -42,7 +42,7 @@ class Compress extends Plugin
     /**
      * @var string
      */
-    public string $schemaVersion = '1.0.0';
+    public string $schemaVersion = '4.0.1';
 
     public bool $hasCpSettings = true;
 

--- a/src/Compress.php
+++ b/src/Compress.php
@@ -15,6 +15,7 @@ use craft\base\Plugin;
 use craft\elements\Asset;
 use craft\events\ModelEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\services\Gc;
 use craft\services\Utilities;
 use craft\web\twig\variables\CraftVariable;
 use venveo\compress\models\Settings;
@@ -85,6 +86,12 @@ class Compress extends Plugin
                 }
             }
         );
+
+        Event::on(Gc::class, Gc::EVENT_RUN, function () {
+            if ($this->getSettings()->deleteStaleArchivesHours) {
+                $this->compress->deleteStaleArchives(25);
+            }
+        });
 
 
         // Register our utility

--- a/src/config.php
+++ b/src/config.php
@@ -30,6 +30,12 @@ return [
      */
     'defaultVolumeHandle' => null,
 
+
+    /**
+     * An optional subdirectory to put zipped files in
+     */
+    'defaultVolumeSubdirectory' => '',
+
     /**
      * If set to true, queue jobs will be dispatched to regenerate an archive
      * if you delete one of its dependent files. Otherwise, this will occur

--- a/src/config.php
+++ b/src/config.php
@@ -29,7 +29,11 @@ return [
      * Default: null
      */
     'defaultVolumeHandle' => null,
-
+    
+    /**
+     * How many hours do we wait before an archive is considered stale?
+     */
+    'deleteStaleArchivesHours' => 0,
 
     /**
      * An optional subdirectory to put zipped files in

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -58,6 +58,7 @@ class Install extends Migration
                     'dateUpdated' => $this->dateTime()->notNull(),
                     'dateLastAccessed' => $this->dateTime()->notNull(),
                     'uid' => $this->uid(),
+                    'filename' => $this->string(),
                     'assetId' => $this->integer(),
                     'hash' => $this->string()->notNull(),
                 ]

--- a/src/migrations/m220617_145938_add_filename_support.php
+++ b/src/migrations/m220617_145938_add_filename_support.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace venveo\compress\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m220617_145938_add_filename_support migration.
+ */
+class m220617_145938_add_filename_support extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn('{{%compress_archives}}', 'filename', $this->string()->after('uid'));
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220617_145938_add_filename_support cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/Archive.php
+++ b/src/models/Archive.php
@@ -81,13 +81,6 @@ class Archive extends Model
      */
     public function getLazyLink(): ?string
     {
-        if ($this->asset instanceof Asset) {
-            // Ensure we _can_ get a url for the asset
-            $assetUrl = $this->asset->getUrl();
-            if($assetUrl) {
-                return $assetUrl;
-            }
-        }
         return UrlHelper::actionUrl('compress/compress/get-link', ['uid' => $this->uid]);
     }
 

--- a/src/models/Archive.php
+++ b/src/models/Archive.php
@@ -13,9 +13,11 @@ namespace venveo\compress\models;
 use craft\base\Model;
 use craft\db\ActiveRecord;
 use craft\elements\Asset;
+use craft\elements\db\AssetQuery;
 use craft\helpers\UrlHelper;
 use DateTime;
 use venveo\compress\Compress as Plugin;
+use yii\base\InvalidConfigException;
 
 /**
  * @author    Venveo
@@ -31,6 +33,7 @@ class Archive extends Model
     public ?string $uid = null;
     public ?int $assetId = null;
     public ?string $hash = null;
+    public ?string $filename = null;
 
     public ?DateTime $dateUpdated;
     public ?DateTime $dateCreated;
@@ -74,6 +77,7 @@ class Archive extends Model
 
     /**
      * @return string|null
+     * @throws InvalidConfigException
      */
     public function getLazyLink(): ?string
     {
@@ -87,9 +91,13 @@ class Archive extends Model
         return UrlHelper::actionUrl('compress/compress/get-link', ['uid' => $this->uid]);
     }
 
-    public function getContents()
+    /**
+     * Returns an AssetQuery configured to include the assets within this archive
+     * @return \craft\elements\db\AssetQuery
+     */
+    public function getContents(): AssetQuery
     {
-        return Plugin::$plugin->compress->getArchiveContents($this);
+        return Plugin::getInstance()->compress->getArchiveContents($this);
     }
 
     /**
@@ -101,7 +109,7 @@ class Archive extends Model
         if (!$this->assetId) {
             return false;
         }
-        if ($this->getAsset() instanceof Asset) {
+        if ($this->getAsset()) {
             return true;
         }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -23,15 +23,29 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * @var string
+     * The handle for the volume where archives are stored
      */
-    public $defaultVolumeHandle = '';
+    public string $defaultVolumeHandle = '';
 
-    public $autoRegenerate = true;
+    /**
+     * An optional subdirectory to put zipped files in
+     */
+    public ?string $defaultVolumeSubdirectory = '';
 
-    public $maxFileSize = 0;
+    /**
+     * Should we automatically regenerate
+     */
+    public bool $autoRegenerate = true;
 
-    public $maxFileCount = 0;
+    /**
+     * The maximum sum of input files we can compress. Set to 0 for no limit
+     */
+    public int $maxFileSize = 0;
+
+    /**
+     * The maximum number of input files we can compress. Set to 0 for no limit
+     */
+    public int $maxFileCount = 0;
 
     /**
      * @inheritdoc
@@ -39,7 +53,7 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-            ['defaultVolumeHandle', 'string'],
+            [['defaultVolumeHandle', 'defaultVolumeSubdirectory'], 'string'],
             [['autoRegenerate'], 'boolean'],
             [['maxFileSize', 'maxFileCount'], 'integer'],
         ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -38,6 +38,11 @@ class Settings extends Model
     public bool $autoRegenerate = true;
 
     /**
+     * How many hours do we wait before an archive is considered stale?
+     */
+    public int $deleteStaleArchivesHours = 0;
+
+    /**
      * The maximum sum of input files we can compress. Set to 0 for no limit
      */
     public int $maxFileSize = 0;
@@ -55,7 +60,7 @@ class Settings extends Model
         return [
             [['defaultVolumeHandle', 'defaultVolumeSubdirectory'], 'string'],
             [['autoRegenerate'], 'boolean'],
-            [['maxFileSize', 'maxFileCount'], 'integer'],
+            [['maxFileSize', 'maxFileCount', 'deleteStaleArchivesHours'], 'integer'],
         ];
     }
 }

--- a/src/records/Archive.php
+++ b/src/records/Archive.php
@@ -16,6 +16,7 @@ use yii\db\ActiveQueryInterface;
  * @property mixed $fileAssets
  * @property integer id
  * @property integer assetId
+ * @property string filename
  * @property \DateTime dateLastAccessed
  * @property string hash
  */
@@ -46,10 +47,8 @@ class Archive extends ActiveRecord
     {
         parent::prepareForDb();
         $now = Db::prepareDateForDb(new DateTime());
-        if ($this->getIsNewRecord()) {
-            if (!isset($this->dateLastAccessed)) {
-                $this->dateLastAccessed = $now;
-            }
+        if ($this->getIsNewRecord() && !isset($this->dateLastAccessed)) {
+            $this->dateLastAccessed = $now;
         }
     }
 }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -24,11 +24,20 @@
 {{ forms.selectField({
     first: true,
     label: 'Default Volume'|t('compress'),
-    instructions: 'Select the volume  for archive storage'|t('compress'),
+    instructions: 'When the Compress plugin is used, the ephemeral archives generated will be stored in this volume.'|t('compress'),
     id: 'defaultVolumeHandle',
     name: 'defaultVolumeHandle',
-    value: settings['defaultVolumeHandle'],
-    options: options
+    value: settings.defaultVolumeHandle,
+    options: options,
+}) }}
+
+{{ forms.textField({
+    name: 'defaultVolumeSubdirectory',
+    label: 'Default Upload Location'|t('compress'),
+    value: settings.defaultVolumeSubdirectory,
+    instructions: "Where archive assets should be stored (relative to **Default Volume**). If this volume doesn't have public URLs, the archives will be proxied through the server to the requester."|t('compress'),
+    placeholder: 'path/to/subfolder'|t('compress'),
+    errors: settings.getErrors('defaultVolumeSubdirectory')
 }) }}
 
 {{ forms.textField({

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -68,3 +68,14 @@
      instructions: 'When enabled, Compress will automatically regenerate archives when one of its dependent files is changed or removed.'|t('compress'),
      on: settings['autoRegenerate'],
  }) }}
+
+
+{{ forms.textField({
+    type:         'number',
+    label:        "How long to wait before an archive is considered stale"|t('compress'),
+    instructions: "Enter how many hours to wait before a generated archive is considered stale and can be deleted."|t('compress'),
+    id:           'deleteStaleArchivesHours',
+    name:         'deleteStaleArchivesHours',
+    value:        settings.deleteStaleArchivesHours,
+    errors:       settings.getErrors('deleteStaleArchivesHours')
+}) }}

--- a/src/variables/CompressVariable.php
+++ b/src/variables/CompressVariable.php
@@ -27,7 +27,7 @@ class CompressVariable
      * @param bool $lazy
      * @return ArchiveModel|null
      */
-    public function zip($query, $lazy = false, $filename = null)
+    public function zip($query, $lazy = false, $filename = null): ?ArchiveModel
     {
         return Compress::$plugin->compress->getArchiveModelForQuery($query, $lazy, $filename);
     }


### PR DESCRIPTION
## 4.0.1 - 2022-06-17
### Added
- Added "Default Volume Subdirectory" settings to control where assets are stored.
- Added ability to specify output archive name (Closes #7)
- Added setting to delete stale archives during garbage collection.
### Changed
- Archives created in volumes without public URLs will now be proxied through the server to be fulfilled
- Files are now streamed into archives instead of being copied to temporary files
- Running "getLazyLink" will now always return a controller URL instead of a direct link to assets. This should help prevent caching issues.